### PR TITLE
Fix NullReferenceException when the Expression is not Conditional

### DIFF
--- a/Mongo.Context/Queryable/QueryExpressionVisitor.cs
+++ b/Mongo.Context/Queryable/QueryExpressionVisitor.cs
@@ -82,7 +82,10 @@ namespace Mongo.Context.Queryable
         {
             if (m.Member.Name == "Value" && m.Member.DeclaringType == typeof(bool?))
             {
-                return ((m.Expression as ConditionalExpression).IfFalse as UnaryExpression).Operand;
+                if (m.Expression is ConditionalExpression)
+                    return ((m.Expression as ConditionalExpression).IfFalse as UnaryExpression).Operand;
+                else
+                    return Visit(m.Expression);
             }
 
             return base.VisitMemberAccess(m);


### PR DESCRIPTION
Fix NullReferenceException when the Expression is not Conditional (but, for example, a PropertyExpression)

This solves an issue when multiple "and/or" filters are combined with a function such as substring. Example url:
/MyService.svc/MyEntity()/$count?$filter=Date gt datetime'2015-02-20T14:14:28.4257345Z' and substringof('code3',Code)

This query resulted in an error before the change. After the change it behaves as expected.